### PR TITLE
Bug fix on PrivateRoute: Defer rendering UI until authentication is confirmed

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,10 +25,19 @@ function App() {
         </Route>
         <PublicRoute Component={SignUpPage} path="/signup" />
         <PublicRoute Component={LogInPage} path="/login" />
-        <PrivateRoute Component={OnBoardingPage} path="/onboarding" />
         <Route path="/authorized" component={Authentication} />
-        <PrivateRoute Component={Scheduler} path="/schedule-meeting" />
-        <PrivateRoute Component={Home} path="/home" />
+
+        <PrivateRoute path="/schedule-meeting">
+          <Scheduler />
+        </PrivateRoute>
+
+        <PrivateRoute path="/home">
+          <Home />
+        </PrivateRoute>
+
+        <PrivateRoute path="/onboarding">
+          <OnBoardingPage />
+        </PrivateRoute>
       </BrowserRouter>
     </MuiThemeProvider>
   );

--- a/client/src/components/Routes/PrivateRoute.js
+++ b/client/src/components/Routes/PrivateRoute.js
@@ -1,21 +1,23 @@
-import React, { useContext, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Route, Redirect } from "react-router-dom";
-import { AuthContext } from "../../providers/AuthProvider";
 import { testAuth } from "../../utils/googleAuth";
+import { useHistory } from "react-router-dom";
 
-const PrivateRoute = ({ Component, ...rest }) => {
-  const { authenticated, setAuthenticated } = useContext(AuthContext);
+const PrivateRoute = ({ children, ...rest }) => {
+  const [authenticated, setAuthenticated] = useState(false);
+  const history = useHistory();
 
-  useEffect(() => testAuth().then(res => setAuthenticated(res)), []);
+  useEffect(() => {
+    testAuth()
+      .then((res) => {
+        setAuthenticated(res);
+      })
+      .catch(() => {
+        history.push("/signup");
+      });
+  }, []);
 
-  return (
-    <Route
-      {...rest}
-      render={props =>
-        authenticated ? <Component {...props} /> : <Redirect to="/login" />
-      }
-    />
-  );
+  return authenticated && <Route {...rest}>{children}</Route>;
 };
 
 export default PrivateRoute;

--- a/client/src/components/Routes/PrivateRoute.js
+++ b/client/src/components/Routes/PrivateRoute.js
@@ -13,7 +13,7 @@ const PrivateRoute = ({ children, ...rest }) => {
         setAuthenticated(res);
       })
       .catch(() => {
-        history.push("/signup");
+        history.push("/login");
       });
   }, []);
 

--- a/client/src/components/Routes/PrivateRoute.js
+++ b/client/src/components/Routes/PrivateRoute.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { Route, Redirect } from "react-router-dom";
 import { testAuth } from "../../utils/googleAuth";
-import { useHistory } from "react-router-dom";
+import { Redirect } from "react-router-dom";
 
 const PrivateRoute = ({ children, ...rest }) => {
   const [authenticated, setAuthenticated] = useState(false);
-  const history = useHistory();
+  const [redirect, setRedirect] = useState(false);
 
   useEffect(() => {
     testAuth()
@@ -13,11 +13,14 @@ const PrivateRoute = ({ children, ...rest }) => {
         setAuthenticated(res);
       })
       .catch(() => {
-        history.push("/login");
+        setRedirect(true);
       });
   }, []);
-
-  return authenticated && <Route {...rest}>{children}</Route>;
+  if (redirect) {
+    return <Redirect to="/login" />;
+  } else {
+    return authenticated && <Route {...rest}>{children}</Route>;
+  }
 };
 
 export default PrivateRoute;


### PR DESCRIPTION
After some discussion with Taras, we worked out a new way to implement <PrivateRoute/> component. It solves the previous bug (not able to handle page refresh) by deferring the UI render until authentication is confirmed. User will be redirected to sign up page if authentication is invalid.