### PR TITLE
Add loading state to context

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,24 +13,13 @@ import UpgradePage from "./pages/UpgradePage";
 import PageNotFound from "./pages/PageNotFound";
 import PrivateRoute from "./components/Routes/PrivateRoute";
 import Checkout from "./pages/Checkout";
-import { useSetAuthenticated } from "./providers/Context";
 import RescheduleOrCancelAppointmentPage from "./pages/reschedule/RescheduleOrCancelAppointmentPage";
 import AppointmentDoesNotExistOrCancelled from "./pages/reschedule/AppointmentDoesNotExistOrCancelled";
-import axios from "axios";
 import UserManagementPage from "./pages/UserManagement";
 
 import "./App.css";
 
 function App() {
-  const setAuthenticated = useSetAuthenticated();
-  useEffect(() => {
-    axios
-      .get("/api/authentication/test", { withCredentials: true })
-      .then(() => {
-        setAuthenticated(true);
-      })
-      .catch();
-  }, [setAuthenticated]);
   return (
     <MuiThemeProvider theme={theme}>
       <BrowserRouter>

--- a/client/src/providers/Context.js
+++ b/client/src/providers/Context.js
@@ -62,17 +62,22 @@ export const UserContextProvider = ({ children }) => {
         setUserData(res.data);
         setDataLoading(false);
       })
-      .catch((err) => console.log(err));
+      .catch(() => {
+        setDataLoading(false);
+      });
   }, []);
 
   useEffect(() => {
     axios
       .get("/api/authentication/test", { withCredentials: true })
       .then(() => {
+        console.log("authenticated");
         setAuthenticated(true);
         setAuthLoading(false);
       })
-      .catch();
+      .catch(() => {
+        setAuthLoading(false);
+      });
   }, []);
 
   return (

--- a/client/src/providers/Context.js
+++ b/client/src/providers/Context.js
@@ -52,6 +52,15 @@ export const UserContextProvider = ({ children }) => {
       .catch((err) => console.log(err));
   }, []);
 
+  useEffect(() => {
+    axios
+      .get("/api/authentication/test", { withCredentials: true })
+      .then(() => {
+        setAuthenticated(true);
+      })
+      .catch();
+  }, [setAuthenticated]);
+
   return (
     <UserContext.Provider
       value={{ userData, setUserData, authenticated, setAuthenticated }}

--- a/client/src/providers/Context.js
+++ b/client/src/providers/Context.js
@@ -37,10 +37,22 @@ export const useSetUserData = () => {
   return useContext(UserContext).setUserData;
 };
 
+// Check whether the app is still fetching auth state
+// Usage:
+// const loading = useAuthLoading(); // true or false
+export const useAuthLoading = () => useContext(UserContext).authLoading;
+
+// Check whether the app is still fetching user data
+// Usage:
+// const loading = useDataLoading(); // true or false
+export const useDataLoading = () => useContext(UserContext).dataLoading;
+
 // CONTEXT PROVIDER SET UP
 export const UserContextProvider = ({ children }) => {
   const [userData, setUserData] = useState([]);
   const [authenticated, setAuthenticated] = useState(false);
+  const [authLoading, setAuthLoading] = useState(true);
+  const [dataLoading, setDataLoading] = useState(true);
 
   // Gets User Data from DB
   useEffect(() => {
@@ -48,6 +60,7 @@ export const UserContextProvider = ({ children }) => {
       .get("/api/user/data")
       .then((res) => {
         setUserData(res.data);
+        setDataLoading(false);
       })
       .catch((err) => console.log(err));
   }, []);
@@ -57,13 +70,21 @@ export const UserContextProvider = ({ children }) => {
       .get("/api/authentication/test", { withCredentials: true })
       .then(() => {
         setAuthenticated(true);
+        setAuthLoading(false);
       })
       .catch();
-  }, [setAuthenticated]);
+  }, []);
 
   return (
     <UserContext.Provider
-      value={{ userData, setUserData, authenticated, setAuthenticated }}
+      value={{
+        userData,
+        setUserData,
+        authenticated,
+        setAuthenticated,
+        authLoading,
+        dataLoading,
+      }}
     >
       {children}
     </UserContext.Provider>


### PR DESCRIPTION
# Summary 

This PR should pave way for our bug fixes involving screen flash and loading spinner.

- Consolidate the auth context. Instead of fetching the authentication state in `App.js`, it now does it in the context provider.
- Add a `dataLoading` and `authLoading` state into context, and their corresponding hooks.

## Hooks

```
import {useAuthLoading, useDataLoading} from "./providers/Context";


const Component = () => {
  const authLoading = useAuthLoading(); // true or false
  const dataLoading = useDataLoading(); // true or false

  // render spinner if authLoading or dataLoading is true. Render actual content when false.
}
