### PR TITLE
Bugfix/redirect to home page

### DIFF
--- a/client/src/components/Routes/PrivateRoute.js
+++ b/client/src/components/Routes/PrivateRoute.js
@@ -1,11 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Route } from "react-router-dom";
-import { useAuth } from "../../providers/Context";
+import { Redirect, Route } from "react-router-dom";
+import { useAuth, useAuthLoading } from "../../providers/Context";
 
 const PrivateRoute = ({ children, ...rest }) => {
   const authenticated = useAuth();
-  return authenticated && <Route {...rest}>{children}</Route>;
+  const loading = useAuthLoading();
+  return (
+    !loading && (
+      <>
+        {authenticated && <Route {...rest}>{children}</Route>}
+        {!authenticated && <Redirect to="/login" />}
+      </>
+    )
+  );
 };
 
 PrivateRoute.propTypes = {


### PR DESCRIPTION
Fixes #110. This branch is based on #123 . The file modified is `src/components/Routes/PrivateRoute.js`

`<PrivateRoute/>` now checks for both loading state and authentication state via the two hooks.

- `loading === true`: do nothing
- `loading === false` & `authenticated === false`: redirect to "/login"
- `loading === false` & `authenticated === true`: render the `children` props
