### PR TITLE
Optimize data fetching in feature/past-appointments

### DIFF
--- a/client/src/components/ScheduledAppointments/IndividualAppointment.js
+++ b/client/src/components/ScheduledAppointments/IndividualAppointment.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import {
   Card,
@@ -9,7 +9,6 @@ import {
   Typography,
 } from "@material-ui/core";
 import { parseISO, format } from "date-fns";
-import axios from "axios";
 
 const IndividualAppointment = ({
   upcoming,

--- a/client/src/components/ScheduledAppointments/IndividualAppointment.js
+++ b/client/src/components/ScheduledAppointments/IndividualAppointment.js
@@ -78,8 +78,10 @@ IndividualAppointment.propTypes = {
   attendeeName: PropTypes.string,
   attendeeEmail: PropTypes.string,
   attendeeTimezone: PropTypes.string,
+  eventName: PropTypes.string,
   time: PropTypes.string,
   duration: PropTypes.number,
+  eventColor: PropTypes.string,
 };
 
 export default IndividualAppointment;

--- a/client/src/components/ScheduledAppointments/IndividualAppointment.js
+++ b/client/src/components/ScheduledAppointments/IndividualAppointment.js
@@ -16,45 +16,32 @@ const IndividualAppointment = ({
   attendeeName,
   attendeeEmail,
   attendeeTimezone,
+  eventName,
   time,
-  eventId,
+  duration,
+  eventColor,
 }) => {
   const parsedDateObj = parseISO(time);
   const formattedTime = format(parsedDateObj, "h:mm b");
   const formattedDate = format(parsedDateObj, "E, LLL do yyyy");
-
-  const [eventDetails, setEventDetails] = useState({});
-  const classes = useStyles({ eventColor: eventDetails.eventColor, upcoming });
-  useEffect(() => {
-    axios.get(`/api/event-details-via-id/${eventId}`).then(({ data }) => {
-      //data: {userId, duration, name, description, color, link, members}
-      setEventDetails({
-        eventName: data.name,
-        eventDescription: data.description,
-        eventColor: data.color,
-        duration: data.duration,
-      });
-    });
-  }, [eventId]);
+  const classes = useStyles({ eventColor, upcoming });
 
   return (
     <Card className={classes.card}>
       <CardHeader className={classes.colorBar} />
       <CardContent className={classes.cardContent}>
         <Grid container spacing={3}>
-          <Grid item xs={6}>
+          <Grid item xs={7}>
             <Typography variant="h4" className={classes.textDisplayingDateTime}>
-              {formattedTime} ({eventDetails.duration} min)
+              {formattedTime} ({duration} min)
             </Typography>
             <Typography variant="h6" className={classes.textDisplayingDateTime}>
               {formattedDate}
             </Typography>
           </Grid>
-          <Grid item xs={6}>
+          <Grid item xs={5}>
             <Typography variant="body1">Attendee: {attendeeName}</Typography>
-            <Typography variant="body1">
-              Event name: {eventDetails.eventName}
-            </Typography>
+            <Typography variant="body1">Event name: {eventName}</Typography>
             <Typography variant="body1">
               Attendee email: {attendeeEmail}
             </Typography>

--- a/client/src/components/ScheduledAppointments/ScheduledAppointmentsTab.js
+++ b/client/src/components/ScheduledAppointments/ScheduledAppointmentsTab.js
@@ -10,14 +10,15 @@ const ScheduledAppointmentsTab = () => {
   const [pastAppointments, setPastAppointments] = useState([]);
 
   useEffect(() => {
+    console.log("hi");
     axios.get("/api/all-appointments").then(({ data }) => {
       // data: [{_id, email, eventId, hostUserId, name, time, timezone},...]
-
+      console.log("all appointments", data);
       const upcomingAppointments = [];
       const pastAppointments = [];
 
       data.forEach((appointment) => {
-        // appointment: {_id, email, eventId, hostUserId, name, time, timezone}
+        // check comments on /api/all-appointments for object keys
         if (appointmentIsUpcoming(appointment.time)) {
           upcomingAppointments.push(appointment);
         } else {
@@ -43,11 +44,12 @@ const ScheduledAppointmentsTab = () => {
             appointmentId={appointment._id} //this is for child access
             upcoming={true}
             attendeeName={appointment.name}
-            time={appointment.time}
-            duration={appointment.duration}
             attendeeEmail={appointment.email}
             attendeeTimezone={appointment.timezone}
-            eventId={appointment.eventId}
+            eventName={appointment.eventName}
+            time={appointment.time}
+            duration={appointment.duration}
+            eventColor={appointment.color}
           />
         ))}
 
@@ -63,11 +65,12 @@ const ScheduledAppointmentsTab = () => {
             appointmentId={appointment._id} //this is for child access
             upcoming={false}
             attendeeName={appointment.name}
-            time={appointment.time}
-            duration={appointment.duration}
             attendeeEmail={appointment.email}
             attendeeTimezone={appointment.timezone}
-            eventId={appointment.eventId}
+            eventName={appointment.eventName}
+            time={appointment.time}
+            duration={appointment.duration}
+            eventColor={appointment.color}
           />
         ))}
     </Grid>

--- a/client/src/components/ScheduledAppointments/ScheduledAppointmentsTab.js
+++ b/client/src/components/ScheduledAppointments/ScheduledAppointmentsTab.js
@@ -10,10 +10,8 @@ const ScheduledAppointmentsTab = () => {
   const [pastAppointments, setPastAppointments] = useState([]);
 
   useEffect(() => {
-    console.log("hi");
     axios.get("/api/all-appointments").then(({ data }) => {
       // data: [{_id, email, eventId, hostUserId, name, time, timezone},...]
-      console.log("all appointments", data);
       const upcomingAppointments = [];
       const pastAppointments = [];
 

--- a/server/routes/appointmentAPI.js
+++ b/server/routes/appointmentAPI.js
@@ -42,6 +42,7 @@ router.post("/api/appointment", async (req, res) => {
 //   link, // the incomplete link for building invitation link: <hostName>/<eventName>
 //   members,
 //   active, // indicate whether the event is active or not
+//   eventName
 // }, ...]
 router.get("/api/all-appointments", auth, async (req, res) => {
   try {

--- a/server/routes/appointmentAPI.js
+++ b/server/routes/appointmentAPI.js
@@ -2,6 +2,7 @@ const express = require("express");
 const db = require("../db/models");
 const auth = require("../middleware/auth");
 const ensureAppointmentExists = require("../middleware/ensureAppointmentExists");
+const getEventDetailViaId = require("../utils/getEventDetailsViaId");
 const router = express.Router();
 
 // CREATE appointment
@@ -25,17 +26,54 @@ router.post("/api/appointment", async (req, res) => {
   }
 });
 
-// GET all appointments for user. Query via userId
-router.get("/api/all-appointments", auth, (req, res) => {
-  db.Appointment.find({ hostUserId: req.userId })
-    .then((data) => {
-      //data: [{_id, email, eventId, hostUserId, name, time, timezone},...]
-      res.send(data);
-    })
-    .catch((error) => {
-      console.log(error);
-      res.status(500).send(error);
-    });
+// GET all appointments for user. Query via userId.
+// Returns an array (could be of length 0) containing the details of the appointment
+// [{
+//   _id, // appointmentId
+//   eventId,
+//   hostUserId,
+//   name, // attendee's name
+//   email, // attendee's email
+//   time, // ISO8601 foramtted date and time
+//   timezone,
+//   duration, // a number in minute
+//   description,
+//   color, // the color of the flag
+//   link, // the incomplete link for building invitation link: <hostName>/<eventName>
+//   members,
+//   active, // indicate whether the event is active or not
+// }, ...]
+router.get("/api/all-appointments", auth, async (req, res) => {
+  try {
+    const appointments = await db.Appointment.find({ hostUserId: req.userId });
+    if (!appointments.length) {
+      throw new Error("noAppointmentsFound");
+    }
+
+    const appointmentsWithEventDetailsPromise = appointments.map(
+      async (appointment) => {
+        const eventDetails = await getEventDetailViaId(appointment.eventId);
+        // Order matters, both of them contain a `name` key,
+        // in eventDetails, that's the event's name,
+        // in appointment, that's the attendee's name
+        // I will save only the attendee's name
+        return { ...eventDetails, ...appointment };
+      }
+    );
+
+    const appointmentsWithEventDetails = await Promise.all(
+      // wait for eveyrthing to resolve
+      appointmentsWithEventDetailsPromise
+    );
+
+    res.status(200).send(appointmentsWithEventDetails);
+  } catch (error) {
+    if (error.message === "noAppointmentsFound") {
+      res.status(400).send("No appointments for the user");
+    } else {
+      res.status(500).send("Error occurred in /api/all-appointments\n", error);
+    }
+  }
 });
 
 router.delete(

--- a/server/routes/appointmentAPI.js
+++ b/server/routes/appointmentAPI.js
@@ -59,7 +59,12 @@ router.get("/api/all-appointments", auth, async (req, res) => {
         // I will save only the attendee's name
         // Also, mongoose query returned object is not a regular object
         // need to convert before spreading
-        return { ...eventDetails.toObject(), ...appointment.toObject() };
+        // big pain
+        return {
+          ...eventDetails.toObject(),
+          ...appointment.toObject(),
+          eventName: eventDetails.name,
+        };
       }
     );
 
@@ -72,7 +77,7 @@ router.get("/api/all-appointments", auth, async (req, res) => {
     if (error.message === "noAppointmentsFound") {
       res.status(400).send("No appointments for the user");
     } else {
-      res.status(500).send("Error occurred in /api/all-appointments\n", error);
+      res.status(500).send("Error occurred in /api/all-appointments\n" + error);
     }
   }
 });

--- a/server/routes/appointmentAPI.js
+++ b/server/routes/appointmentAPI.js
@@ -57,12 +57,13 @@ router.get("/api/all-appointments", auth, async (req, res) => {
         // in eventDetails, that's the event's name,
         // in appointment, that's the attendee's name
         // I will save only the attendee's name
-        return { ...eventDetails, ...appointment };
+        // Also, mongoose query returned object is not a regular object
+        // need to convert before spreading
+        return { ...eventDetails.toObject(), ...appointment.toObject() };
       }
     );
 
     const appointmentsWithEventDetails = await Promise.all(
-      // wait for eveyrthing to resolve
       appointmentsWithEventDetailsPromise
     );
 

--- a/server/routes/appointmentAPI.js
+++ b/server/routes/appointmentAPI.js
@@ -54,13 +54,7 @@ router.get("/api/all-appointments", auth, async (req, res) => {
     const appointmentsWithEventDetailsPromise = appointments.map(
       async (appointment) => {
         const eventDetails = await getEventDetailViaId(appointment.eventId);
-        // Order matters, both of them contain a `name` key,
-        // in eventDetails, that's the event's name,
-        // in appointment, that's the attendee's name
-        // I will save only the attendee's name
-        // Also, mongoose query returned object is not a regular object
-        // need to convert before spreading
-        // big pain
+        // spread eventDetails first because of duplicate keys
         return {
           ...eventDetails.toObject(),
           ...appointment.toObject(),

--- a/server/utils/getEventDetailsViaId.js
+++ b/server/utils/getEventDetailsViaId.js
@@ -2,12 +2,8 @@ const db = require("../db/models");
 
 // Returns a promise that resolves to an object containing the details of the
 // event. This function can be optimized by hooking it onto a cache object
-const getEventDetailViaId = async (eventId) => {
-  const eventDetails = await db.EventType.findOne({ _id: eventId });
-  return {
-    ...eventDetails.toObject(),
-    eventName: eventDetails.name,
-  };
+const getEventDetailViaId = (eventId) => {
+  return db.EventType.findOne({ _id: eventId });
 };
 
 module.exports = getEventDetailViaId;

--- a/server/utils/getEventDetailsViaId.js
+++ b/server/utils/getEventDetailsViaId.js
@@ -1,0 +1,7 @@
+// Returns a promise that resolves to an object containing the details of the
+// event. This function can be optimized by hooking it onto a cache object
+const getEventDetailViaId = (eventId) => {
+  return db.EventTypes.findOne({ _id: eventId });
+};
+
+module.exports = getEventDetailViaId;

--- a/server/utils/getEventDetailsViaId.js
+++ b/server/utils/getEventDetailsViaId.js
@@ -2,12 +2,12 @@ const db = require("../db/models");
 
 // Returns a promise that resolves to an object containing the details of the
 // event. This function can be optimized by hooking it onto a cache object
-const getEventDetailViaId = (eventId) => {
+const getEventDetailViaId = async (eventId) => {
   const eventDetails = await db.EventType.findOne({ _id: eventId });
   return {
     ...eventDetails.toObject(),
-    eventName: eventDetails.name
-  }
+    eventName: eventDetails.name,
+  };
 };
 
 module.exports = getEventDetailViaId;

--- a/server/utils/getEventDetailsViaId.js
+++ b/server/utils/getEventDetailsViaId.js
@@ -1,7 +1,13 @@
+const db = require("../db/models");
+
 // Returns a promise that resolves to an object containing the details of the
 // event. This function can be optimized by hooking it onto a cache object
 const getEventDetailViaId = (eventId) => {
-  return db.EventTypes.findOne({ _id: eventId });
+  const eventDetails = await db.EventType.findOne({ _id: eventId });
+  return {
+    ...eventDetails.toObject(),
+    eventName: eventDetails.name
+  }
 };
 
 module.exports = getEventDetailViaId;


### PR DESCRIPTION
This PR addresses Dan's [comment](https://github.com/hatchways/team-yugioh/pull/109#discussion_r568620184) and today's discussion on making the data flow more efficient (I'm opening a new one here so it's easier to review)

- When querying `/api/all-appointments`, the backend do all the hard lifting to combine the details for the appointment and event type and send it to front end.
- The eventdetails is obtained by calling the function `getEventDetailsViaId(eventId)`, which can later be hooked up to a cache object (I can implement that if this set up looks good to everyone).
- `<IndividualAppointment/>` no longer needs to do its own data fetching 