### PR TITLE
Add object id format check in feature/past-appointments

### DIFF
--- a/server/db/models/Appointment.js
+++ b/server/db/models/Appointment.js
@@ -7,7 +7,7 @@ const schema = new Schema({
     type: mongoose.Schema.Types.ObjectId,
   },
   hostUserId: {
-    type: String, // Using string type here to prevent type conversion error since all we care if whether a given id value matches it
+    type: mongoose.Schema.Types.ObjectId,
   },
   name: {
     type: String,

--- a/server/middleware/ensureAppointmentExists.js
+++ b/server/middleware/ensureAppointmentExists.js
@@ -1,3 +1,4 @@
+const validateObjId = require("mongoose").Types.ObjectId;
 const dbAppointment = require("../db/models/Appointment");
 
 const ensureAppointmentExists = async (req, res, next) => {
@@ -13,6 +14,8 @@ const ensureAppointmentExists = async (req, res, next) => {
 
   const { appointmentId } = req.params;
   try {
+    stringIsValidObjectId(appointmentId);
+
     //result will return undefined when appointmentId is a valid format but does not exist in database
     const result = await dbAppointment.findOne({ _id: appointmentId });
     if (result) {
@@ -23,11 +26,22 @@ const ensureAppointmentExists = async (req, res, next) => {
     }
   } catch (error) {
     // the await statement will fail if the appointmentId is in a non-valid format
-    res
-      .status(400)
-      .send(
-        "No appointment found for the provided ID (Error in ensureAppointmentExists mdidleware"
-      );
+    if (error.message === "invalidObjId") {
+      res.status(400).send("Invalid format in appointment id");
+    } else {
+      res
+        .status(400)
+        .send(
+          "No appointment found for the provided ID (Error in ensureAppointmentExists mdidleware"
+        );
+    }
+  }
+};
+
+// throw an error if the string is not in valid object id format
+const stringIsValidObjectId = (stringValue) => {
+  if (!validateObjId(stringValue)) {
+    throw new Error("invalidObjId");
   }
 };
 

--- a/server/middleware/ensureAppointmentExists.js
+++ b/server/middleware/ensureAppointmentExists.js
@@ -1,4 +1,4 @@
-const validateObjId = require("mongoose").Types.ObjectId;
+const isObjectIdValid = require("mongoose").Types.ObjectId.isValid;
 const dbAppointment = require("../db/models/Appointment");
 
 const ensureAppointmentExists = async (req, res, next) => {
@@ -38,9 +38,10 @@ const ensureAppointmentExists = async (req, res, next) => {
   }
 };
 
-// throw an error if the string is not in valid object id format
+// throw an error if the string is not in valid object id format (valid if
+// it is a 12 characters long string)
 const stringIsValidObjectId = (stringValue) => {
-  if (!validateObjId(stringValue)) {
+  if (!isObjectIdValid(stringValue)) {
     throw new Error("invalidObjId");
   }
 };


### PR DESCRIPTION
- `hostUserId` uses `ObjectId` type in database
- Added format check for the object Id and send a "invalid format" error 
- It appears that the validate function from mongoose library function only checks whether the string is 12 characters long (future improvement)