### PR TITLE
Fix bugs: orphan invalid appointment that do not have matching event

### DIFF
--- a/server/routes/appointmentAPI.js
+++ b/server/routes/appointmentAPI.js
@@ -55,6 +55,9 @@ router.get("/api/all-appointments", auth, async (req, res) => {
       async (appointment) => {
         const eventDetails = await getEventDetailViaId(appointment.eventId);
         // spread eventDetails first because of duplicate keys
+        if (!eventDetails) {
+          return undefined;
+        }
         return {
           ...eventDetails.toObject(),
           ...appointment.toObject(),
@@ -63,9 +66,9 @@ router.get("/api/all-appointments", auth, async (req, res) => {
       }
     );
 
-    const appointmentsWithEventDetails = await Promise.all(
-      appointmentsWithEventDetailsPromise
-    );
+    const appointmentsWithEventDetails = (
+      await Promise.all(appointmentsWithEventDetailsPromise)
+    ).filter((appointment) => appointment); //filter those that return undefined
 
     res.status(200).send(appointmentsWithEventDetails);
   } catch (error) {


### PR DESCRIPTION
I identified the reason why past-appointment was breaking. If there's already an appointment booked, but we delete the event type, then the `/api/all-appointments` can't figure out what to do (doesn't handle a null object well)

I added a filter command to remove those without matching event types.